### PR TITLE
added licence to setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ setup(
     download_url='https://github.com/bazerk/uk-modulus-checking/tarball/0.1',
     keywords=['uk', 'banking', 'validation'],
     classifiers=[],
+    licence='MIT',
 )


### PR DESCRIPTION
My jenkins job is unable to fetch the licensing as it is not specified in the setup.py file, as suggested in https://docs.python.org/2/distutils/setupscript.html. This would be very helpful.
