### PR TITLE
Deal with non-Santander 9-digit account codes. Resolves #5.

### DIFF
--- a/ukmodulus/__init__.py
+++ b/ukmodulus/__init__.py
@@ -102,7 +102,16 @@ def _normalize_account_number_and_code(account_number, sort_code):
             return account_number[:8], sort_code
         return account_number[-8:], sort_code
     elif ln == 9:
-        return account_number[-8:], sort_code[:-1] + account_number[0]
+        def is_santander_sort_code():
+            return (sort_code >= "090000" and sort_code <= "091900") or \
+		(sort_code >= "720000" and sort_code <= "729999") or \
+		(sort_code >= "890000" and sort_code <= "892999") or \
+		sort_code == "165710"
+
+        if is_santander_sort_code():
+            return account_number[-8:], sort_code[:-1] + account_number[0]
+        else:
+            return account_number[-8:], sort_code
     else:
         return '{:08}'.format(int(account_number)), sort_code
 

--- a/ukmodulus/tests.py
+++ b/ukmodulus/tests.py
@@ -18,7 +18,14 @@ class SimpleValidationTests(unittest.TestCase):
             # account_number, sortcode, expected_account_number, expected_sort_code
             ('0123456789', '090050', '23456789', '090050'),
             ('0123456789', '080050', '01234567', '080050'),
-            ('123456789', '080050', '23456789', '080051'),
+            #
+            # 9-digit, Santander case.
+            #
+            ('123456789', '090050', '23456789', '090051'),
+            #
+            # 9-digit, non-Santander (Coventry Building Society) case.
+            #
+            ('123456789', '406301', '23456789', '406301'),
             ('1234567', '080050', '01234567', '080050'),
             ('123456', '080050', '00123456', '080050'),
         ]


### PR DESCRIPTION
My patch is based on [the code](https://gist.github.com/dancannon/97d7d52570b76709890eef3e61e1db93) provided by the reporter of #5, with tests updated to suit..